### PR TITLE
GetSteamSourcemodPath function

### DIFF
--- a/Code/beacon/beacon.cpp
+++ b/Code/beacon/beacon.cpp
@@ -3,9 +3,21 @@
 int main() {
   auto p = new palace; // does sanity checks
   p->get_server_games();
-  if(p->init_games()==1){
-    printf("non-adastral game in folder\n");
-  };
+  int code = p->init_games();
+
+  switch (code)
+  {
+    case 0:
+        printf("Initialization success!\n");
+        break;
+    case 1:
+        printf("non-adastral game in folder\n");
+        break;
+    case 2:
+        printf("Steam sourcemods dir was not found. Is steam installed?\n");
+        return code;
+  }
+
   p->update_game("open_fortress");
   return 0;
 }

--- a/Code/moss/moss.cpp
+++ b/Code/moss/moss.cpp
@@ -133,7 +133,7 @@ inline bool Is64BitWindows()
 }
 #endif
 
-static std::filesystem::path moss::GetSteamSourcemodPath()
+std::filesystem::path moss::GetSteamSourcemodPath()
 {
 #if _WIN32
 	char valueData[MAX_PATH];
@@ -141,7 +141,15 @@ static std::filesystem::path moss::GetSteamSourcemodPath()
 
 	//Check if this is 64 bit or 32 bit process
 	const char* subKey = Is64BitWindows() ? "SOFTWARE\\WOW6432Node\\Valve\\Steam" : "\\SOFTWARE\\Valve\\Steam";
+
+    //Get steam install dir from registry
 	RegGetValueA(HKEY_LOCAL_MACHINE, subKey, "InstallPath", RRF_RT_ANY, nullptr, &valueData, &valueLen);
+    if (valueData[0] == 0)
+    {
+        //Registry key did not exist/had no value
+        return std::filesystem::path();
+    }
+
 	return std::filesystem::path(valueData) / "steamapps\\sourcemods";
 #else
 	//Return normal steam path or use sym link version

--- a/Code/moss/moss.cpp
+++ b/Code/moss/moss.cpp
@@ -112,3 +112,40 @@ int moss::sanity_checks() {
   curl_data = "";
   return 0;
 }
+
+#if _WIN32
+inline bool Is64BitWindows()
+{
+#if _WIN64
+    return true;
+#else
+    USHORT ProcessMachine;
+    USHORT NativeMachine;
+    BOOL IsWow64 = IsWow64Process2(GetCurrentProcess(), &ProcessMachine, &NativeMachine);
+
+    if(IsWow64)
+    {
+        if(NativeMachine == IMAGE_FILE_MACHINE_AMD64) return true;
+    }
+
+    return false;
+#endif
+}
+#endif
+
+static std::filesystem::path moss::GetSteamSourcemodPath()
+{
+#if _WIN32
+	char valueData[MAX_PATH];
+	DWORD valueLen = MAX_PATH;
+
+	//Check if this is 64 bit or 32 bit process
+	const char* subKey = Is64BitWindows() ? "SOFTWARE\\WOW6432Node\\Valve\\Steam" : "\\SOFTWARE\\Valve\\Steam";
+	RegGetValueA(HKEY_LOCAL_MACHINE, subKey, "InstallPath", RRF_RT_ANY, nullptr, &valueData, &valueLen);
+	return std::filesystem::path(valueData) / "steamapps\\sourcemods";
+#else
+	//Return normal steam path or use sym link version
+	auto normal_steam_linux =  std::filesystem::path("~/.local/share/Steam/steamapps/sourcemods");
+	return std::filesystem::exists(normal_steam_linux) ? normal_steam_linux : std::filesystem::path("~/.steam/steam/steamapps/sourcemods");
+#endif
+}

--- a/Code/moss/moss.hpp
+++ b/Code/moss/moss.hpp
@@ -19,7 +19,7 @@ class moss {
   std::string get_string_data_from_server(const std::string& url);
 
   //Get path object for the systems sourcemods folder (win/linux)
-  static std::filesystem::path GetSteamSourcemodPath();
+  std::filesystem::path GetSteamSourcemodPath();
 
  private:
   static size_t static_curl_callback(void *buffer, size_t sz, size_t n, void *cptr);

--- a/Code/moss/moss.hpp
+++ b/Code/moss/moss.hpp
@@ -17,6 +17,7 @@ class moss {
   static bool CheckSDKInstalled(const std::filesystem::path& steamDir);
   int sanity_checks();
   std::string get_string_data_from_server(const std::string& url);
+  static std::filesystem::path GetSteamSourcemodPath();
  private:
   static size_t static_curl_callback(void *buffer, size_t sz, size_t n, void *cptr);
   void curl_callback(void *buffer, size_t sz, size_t n); // callback for the below. string only. we could r

--- a/Code/moss/moss.hpp
+++ b/Code/moss/moss.hpp
@@ -17,7 +17,10 @@ class moss {
   static bool CheckSDKInstalled(const std::filesystem::path& steamDir);
   int sanity_checks();
   std::string get_string_data_from_server(const std::string& url);
+
+  //Get path object for the systems sourcemods folder (win/linux)
   static std::filesystem::path GetSteamSourcemodPath();
+
  private:
   static size_t static_curl_callback(void *buffer, size_t sz, size_t n, void *cptr);
   void curl_callback(void *buffer, size_t sz, size_t n); // callback for the below. string only. we could r

--- a/Code/palace/palace.cpp
+++ b/Code/palace/palace.cpp
@@ -2,6 +2,11 @@
 
 palace::palace() {
   moss().sanity_checks();
+
+  sourcemodsPath = moss::GetSteamSourcemodPath();
+#if _DEBUG
+    printf("Soucemods dir: %s\n", sourcemodsPath.string().c_str());
+#endif
 }
 
 void palace::get_server_games() {
@@ -10,12 +15,16 @@ void palace::get_server_games() {
 
 
 int palace::init_games() {
-  std::filesystem::path smPath = "/home/rr/.steam/steam/steamapps/sourcemods";
+  if (!std::filesystem::exists(sourcemodsPath))
+  {
+    return 2;
+  }
+
   for(const auto& it: southbankJson["games"].items()){
     std::string version;
-    if(std::filesystem::exists(smPath / it.key())) {
+    if(std::filesystem::exists(sourcemodsPath / it.key())) {
       std::cout << it.key() << ": Game exists. " <<std::endl;
-      std::ifstream data(smPath / it.key() / ".adastral");
+      std::ifstream data(sourcemodsPath / it.key() / ".adastral");
       if (data.fail()) {
         return 1;  // TODO: handle this properly. we also need to check the json's not invalid but uhhh idk since it's a stream
       }
@@ -25,7 +34,7 @@ int palace::init_games() {
       std::string full_url = southbankJson["dl_url"];
       full_url += it.key();
       full_url += '/'; // this is dumb, make it do this inside kachemak....
-      auto* game = new Kachemak(smPath,it.key(),full_url,version); // getting the json is versioning impl specific so we let it get it
+      auto* game = new Kachemak(sourcemodsPath,it.key(),full_url,version); // getting the json is versioning impl specific so we let it get it
       // i'm aware i'm breaking one of the rules, but it makes more sense
       serverGames[it.key()] = game;
   }

--- a/Code/palace/palace.cpp
+++ b/Code/palace/palace.cpp
@@ -3,7 +3,7 @@
 palace::palace() {
   moss().sanity_checks();
 
-  sourcemodsPath = moss::GetSteamSourcemodPath();
+  sourcemodsPath = moss().GetSteamSourcemodPath();
 #if _DEBUG
     printf("Soucemods dir: %s\n", sourcemodsPath.string().c_str());
 #endif

--- a/Code/palace/palace.hpp
+++ b/Code/palace/palace.hpp
@@ -48,4 +48,8 @@ class palace {
 
   nlohmann::json southbankJson;
   std::unordered_map<std::string,Kachemak*> serverGames;
+
+private:
+	//Path to users sourcemods folder
+	std::filesystem::path sourcemodsPath;
 };


### PR DESCRIPTION
Adds function to locate steam sourcemods dir on linux and windows.
Print error and exit if path does not exist.

Windows tested but not linux.