### PR TITLE
Setting GH Actions for Build Windows to Release

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        BUILD_TYPE: [ Debug ]
+        BUILD_TYPE: [ Release ]
     steps:
       - uses: actions/checkout@v3
       - uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
Changing it to the release type instead of debug type.